### PR TITLE
free memory for items before allocating more

### DIFF
--- a/dsofinder.cpp
+++ b/dsofinder.cpp
@@ -34,6 +34,8 @@ DsoFinder::DsoFinder(int argc,char* argv[],QWidget *parent) :
     avatar_heigth = 280;
     bg_exist = false;
     bg_count = get_bgcount(); //CHECK CURRENT DIRECTORY FOR VALID BACKGROUND FILES
+    itemcount = 0;
+
     load_settings(); //LOAD USER-DEFINED VARIABLES
     check_version(); //CHECK FOR OUT OF DATE VERSION
     init_events(); //LOOK AT events.cpp FOR LIST OF EVENTS

--- a/items.cpp
+++ b/items.cpp
@@ -10,6 +10,15 @@
 
 void DsoFinder::init_items()
 {
+    // free memory if items already declared
+    if (itemcount != 0)
+    {
+        for(int i = 0; i < itemcount; i++)
+            delete [] items[i].shape;
+
+        delete [] items;
+    }
+
     borderbox = 10;
     itemcount = 0;
     if(config.useitems_basic) itemcount += 8;


### PR DESCRIPTION
every time the event is switched, more memory is allocated with new [], but the old one is not freed.
