### PR TITLE
Detect player avatar

### DIFF
--- a/dsofinder.cpp
+++ b/dsofinder.cpp
@@ -261,8 +261,8 @@ void DsoFinder::on_findButton_clicked()
         player_avatar_data player_avatar;
 
         //MAIN SEARCH ALGORITHM
-        for(int x=borderbox;x<originalPixmap.width()-borderbox;x++) {       //SCAN IMAGE (X)
-            for(int y=borderbox;y<originalPixmap.height()-borderbox;y++) {  //SCAN IMAGE (Y)
+        for(int x=0;x<originalPixmap.width();x++) {       //SCAN IMAGE (X)
+            for(int y=0;y<originalPixmap.height();y++) {  //SCAN IMAGE (Y)
                 for(int i=0;i<itemcount;i++) {                          //SCAN FOR ALL DEFINED ITEMS (items.cpp)
                     bool item_found = false;
                     for(int j=0; j<items[i].shapecount; j++) {            //SCAN FOR ALL DEFINED SHAPES
@@ -272,12 +272,22 @@ void DsoFinder::on_findButton_clicked()
                             for(int k=0; k<items[i].shape[j].pixelcount; k++) //SCAN ALL DEFINED PIXELS OF ITEMS
                             {
                                 if(items[i].shape[j].pixelcount - items[i].shape[j].needed + shape_disc >= k) { //SPEED UP IF DISCOVERY IMPOSSIBLE
-                                    if( pixels[x+items[i].shape[j].pixel[k].pos.x_pos][y+items[i].shape[j].pixel[k].pos.y_pos][0]>items[i].shape[j].pixel[k].r.min &&
-                                        pixels[x+items[i].shape[j].pixel[k].pos.x_pos][y+items[i].shape[j].pixel[k].pos.y_pos][0]<items[i].shape[j].pixel[k].r.max &&
-                                        pixels[x+items[i].shape[j].pixel[k].pos.x_pos][y+items[i].shape[j].pixel[k].pos.y_pos][1]>items[i].shape[j].pixel[k].g.min &&
-                                        pixels[x+items[i].shape[j].pixel[k].pos.x_pos][y+items[i].shape[j].pixel[k].pos.y_pos][1]<items[i].shape[j].pixel[k].g.max &&
-                                        pixels[x+items[i].shape[j].pixel[k].pos.x_pos][y+items[i].shape[j].pixel[k].pos.y_pos][2]>items[i].shape[j].pixel[k].b.min &&
-                                        pixels[x+items[i].shape[j].pixel[k].pos.x_pos][y+items[i].shape[j].pixel[k].pos.y_pos][2]<items[i].shape[j].pixel[k].b.max)
+                                    int trans_x = x + items[i].shape[j].pixel[k].pos.x_pos;
+                                    int trans_y = y + items[i].shape[j].pixel[k].pos.y_pos;
+
+                                    // make sure that the pixel we are looking at is within bounds
+                                    if (trans_x < 0 || trans_x >= d_width ||
+                                        trans_y < 0 || trans_y >= d_heigth)
+                                    {
+                                        continue;
+                                    }
+
+                                    if( pixels[trans_x][trans_y][0] > items[i].shape[j].pixel[k].r.min &&
+                                        pixels[trans_x][trans_y][0] < items[i].shape[j].pixel[k].r.max &&
+                                        pixels[trans_x][trans_y][1] > items[i].shape[j].pixel[k].g.min &&
+                                        pixels[trans_x][trans_y][1] < items[i].shape[j].pixel[k].g.max &&
+                                        pixels[trans_x][trans_y][2] > items[i].shape[j].pixel[k].b.min &&
+                                        pixels[trans_x][trans_y][2] < items[i].shape[j].pixel[k].b.max)
                                     {
                                         if(!items[i].shape[j].pixel[k].negating) shape_disc++;
                                         else shape_negating=true;

--- a/dsofinder.cpp
+++ b/dsofinder.cpp
@@ -64,7 +64,7 @@ void DsoFinder::on_takeButton_clicked()
     if(!config.jump_position) config.position_small = this->pos();
     set_optionwindow(false);
     if(!config.stay_big) {
-        set_gui(true,debug);
+        hide();
         QElapsedTimer timer;
         timer.start();
         while(timer.elapsed()< config.waittime);                  // WAIT 600ms FOR PROPER RESIZING ON SLOWER MACHINES
@@ -75,7 +75,8 @@ void DsoFinder::on_takeButton_clicked()
     if (const QWindow *window = windowHandle())
         screen = window->screen();
     if (!screen) {
-        set_gui(false,debug);
+        if(!config.stay_big)
+            show();
         return;
     }
     originalPixmap = screen->grabWindow(0);
@@ -97,6 +98,10 @@ void DsoFinder::on_takeButton_clicked()
     //RESIZE TO FULL AND SHOW SCREENSHOT
     ui->screenlabel->setPixmap(originalPixmap.scaled(ui->screenlabel->size(),Qt::KeepAspectRatio,Qt::SmoothTransformation));
     set_gui(false,debug);
+
+    // show UI if it was hidden
+    if(!config.stay_big)
+        show();
 }
 
 void DsoFinder::resizeEvent(QResizeEvent *event)

--- a/dsofinder.h
+++ b/dsofinder.h
@@ -60,8 +60,18 @@ public:
         QColor color;
         QColor alt_color;
         Qt::PenStyle penstyle;
+        int width;
+        int height;
 
-        item():item_type("standard"){}
+        item():item_type("standard"), width(0), height(0) {}
+    };
+
+    struct player_avatar_data {
+        bool found;
+        pixel_pos min_pos;
+        pixel_pos max_pos;
+
+        player_avatar_data():found(false){}
     };
 
     struct event {
@@ -102,7 +112,6 @@ public:
     item* items;
     int itemcount;
     int*** pixels;
-    int avatar_width, avatar_heigth;
     QVector<QVector<int> > discovery;
 
     //BUILDING_SITE_RELATED OBJECTS/VARIABLES
@@ -140,7 +149,7 @@ public:
     void setactive(bool active);
     void activate_buttons(bool activate);
     void log_discoverys();
-    void validate_discoverys();
+    void validate_discoverys(player_avatar_data player_avatar);
     void draw_valids();
     void draw_discovery(QPoint coords, QColor color, Qt::PenStyle style);
     void init_items();
@@ -156,6 +165,8 @@ public:
     bool is_brigth(int g);
 
     void populate_event_combo();
+    pixel_data getPixel(int r, int g, int b, int epsilon, int x_pos, int y_pos);
+    pixel_data getPixel(int r_min, int r_max, int g_min, int g_max, int b_min, int b_max, int x, int y);
 protected:
     void resizeEvent(QResizeEvent* event);
     void changeEvent(QEvent *e);

--- a/dsofinder.h
+++ b/dsofinder.h
@@ -132,7 +132,7 @@ public:
     QImage originalImage;
 
     int totaldiscoverys;
-    int d_width,d_heigth,borderbox;
+    int d_width,d_heigth;
 
     bool debug;
     bool current_ontop_windowsetting;

--- a/items.cpp
+++ b/items.cpp
@@ -5,7 +5,6 @@
 // itemcount = TOTAL NUMBER OF ITEMS
 // items.shapecount = TOTAL NUMBER OF DIFFERENT PATTERNS OR SHAPES FOR ONE ITEM
 // items.shape.pixelcount = TOTAL NUMBER OF DEFINED PIXELS PER SHAPE
-// borderbox = AT LEAST THE MAXIMUM SPREAD OF RELATIVE X AND Y POSITIONS +1. IF DEFINED PIXELS HAVE e.g.: -1, -4, 2, 3 AS RELATIVE pos, THEN borderbox MUST BE AT LEAST 5! (abs(-4)+1)
 // FAILURE IN ANY OF THIS MAY LEAD TO CRASHES
 
 void DsoFinder::init_items()
@@ -19,7 +18,6 @@ void DsoFinder::init_items()
         delete [] items;
     }
 
-    borderbox = 10;
     itemcount = 1;  // initialize to 1 for player avatar
     if(config.useitems_basic) itemcount += 8;
     if(config.useitems_adventure) itemcount += 2;

--- a/items.cpp
+++ b/items.cpp
@@ -20,7 +20,7 @@ void DsoFinder::init_items()
     }
 
     borderbox = 10;
-    itemcount = 0;
+    itemcount = 1;  // initialize to 1 for player avatar
     if(config.useitems_basic) itemcount += 8;
     if(config.useitems_adventure) itemcount += 2;
 
@@ -31,6 +31,25 @@ void DsoFinder::init_items()
 
     items = new item[itemcount];
     int i=0;
+
+    // player area
+    items[i].caption = "Player Avatar";
+    items[i].item_type = "player_avatar";
+    items[i].color = QColor(0,0,0);
+    items[i].alt_color = QColor(0,0,0);
+    items[i].penstyle = Qt::SolidLine;
+    items[i].width = 123;
+    items[i].height = 299;
+    items[i].shapecount = 1;
+    items[i].shape = new item_shape[items[i].shapecount];
+    items[i].shape[0].needed = 3;
+    items[i].shape[0].pixelcount = 4;
+    items[i].shape[0].pixel = new pixel_data[items[i].shape[0].pixelcount];
+    items[i].shape[0].pixel[0] = getPixel(255, 255,   0, 5, 124, 137);
+    items[i].shape[0].pixel[1] = getPixel(210,  35,  29, 5, 114, 134);
+    items[i].shape[0].pixel[2] = getPixel(179,  69,  57, 5, 94, 288);
+    items[i].shape[0].pixel[3] = getPixel(167,  64,  53, 5, 94, 397);
+    i++;
 
     if(!config.usehalfsize) //All Items for normal size
     {
@@ -2184,4 +2203,31 @@ void DsoFinder::init_items()
 
         }
     }
+}
+
+DsoFinder::pixel_data DsoFinder::getPixel(int r, int g, int b, int epsilon, int x_pos, int y_pos) {
+    pixel_data pixel;
+    // clamp to -1 / 256 because of </> instead of <=/>= comparison
+    pixel.r.min = std::max(-1, r - epsilon);
+    pixel.r.max = std::min(256, r + epsilon);
+    pixel.g.min = std::max(-1, g - epsilon);
+    pixel.g.max = std::min(256, g + epsilon);
+    pixel.b.min = std::max(-1, b - epsilon);
+    pixel.b.max = std::min(256, b + epsilon);
+    pixel.pos.x_pos = x_pos;
+    pixel.pos.y_pos = y_pos;
+    return pixel;
+}
+
+DsoFinder::pixel_data DsoFinder::getPixel(int r_min, int r_max, int g_min, int g_max, int b_min, int b_max, int x, int y) {
+    pixel_data pixel;
+    pixel.r.min = r_min;
+    pixel.r.max = r_max;
+    pixel.g.min = g_min;
+    pixel.g.max = g_max;
+    pixel.b.min = b_min;
+    pixel.b.max = b_max;
+    pixel.pos.x_pos = x;
+    pixel.pos.y_pos = y;
+    return pixel;
 }


### PR DESCRIPTION
Using a set position for the player avatar assumes quite a few things and is thrown off by taksbars on the side (like Ubuntu Unity Launcher, or Windows 7 with it dragged to the side), a fullscreen browser etc.
This patch uses item detection to find the avatar no matter where it is.
It also gets rid of the borderbox.
